### PR TITLE
Synjitsu/delay/wait_for_key per domain, travis, logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+sudo: required
+env:
+  global:
+  - ALCOTEST_SHOW_ERRORS=1
+  - PACKAGE=jitsu.0.2.0
+  matrix:
+  - OCAML_VERSION=4.01
+  - OCAML_VERSION=4.02

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 env:
   global:
   - ALCOTEST_SHOW_ERRORS=1
-  - PACKAGE=jitsu.0.2.0
+  - PACKAGE=jitsu
   matrix:
   - OCAML_VERSION=4.01
-  - OCAML_VERSION=4.02

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPT=-linkpkg -g
 OCAMLOPT=ocamlopt -w A-4-44
 
 SRC=$(PWD)/src
-FILES=vm_stop_mode.ml vm_state.ml backends.mli options.ml rumprun.ml libvirt_backend.ml xapi_backend.ml libxl_backend.ml irmin_backend.mli dns_helpers.ml irmin_backend.ml synjitsu.mli synjitsu.ml jitsu.mli jitsu.ml
+FILES=vm_stop_mode.ml vm_state.ml xenstore.ml backends.mli options.ml rumprun.ml libvirt_backend.ml xapi_backend.ml libxl_backend.ml irmin_backend.mli dns_helpers.ml irmin_backend.ml synjitsu.mli synjitsu.ml jitsu.mli jitsu.ml
 MAIN=main.ml
 
 TEST_SRC=$(PWD)/lib_test

--- a/lib_test/test_options.ml
+++ b/lib_test/test_options.ml
@@ -32,6 +32,11 @@ let hashtbl =
   Hashtbl.add t "tuple_str_list" "l:r";
   Hashtbl.add t "tuple_str_list" ":";
   Hashtbl.add t "tuple_str_list" "";
+  Hashtbl.add t "bool" "0";
+  Hashtbl.add t "bool_list" "true";
+  Hashtbl.add t "bool_list" "false";
+  Hashtbl.add t "bool_list" "0";
+  Hashtbl.add t "bool_list" "1";
   t
 
 let test_get_int () =
@@ -55,6 +60,22 @@ let test_get_str_list () =
   | `Ok s -> Alcotest.(check (list string)) "string list" expected s
   | `Error e -> Alcotest.fail (Options.string_of_error e)
 
+let test_get_bool () =
+  match (Options.get_bool hashtbl "bool") with
+  | `Ok s -> if not s = false then Alcotest.fail "expected false"
+  | `Error e -> Alcotest.fail (Options.string_of_error e)
+
+let test_get_bool_list () =
+  let expected = [ true ; false ; false ; true ] in
+  match (Options.get_bool_list hashtbl "bool_list") with
+  | `Ok s -> let _ = List.map2 (fun a b ->
+      if not a=b then
+        Alcotest.fail (Printf.sprintf "Bool lists are not equal. Expected %B, got %B" a b)
+      else
+        ()) expected s in
+    ()
+  | `Error e -> Alcotest.fail (Options.string_of_error e)
+  
 let test_get_dns_name () =
   match (Options.get_dns_name hashtbl "dns_name") with
   | `Ok i -> Alcotest.(check string) "dns_name" "www.example.org" (Dns.Name.to_string i)
@@ -90,7 +111,7 @@ let test_get_str_tuple_list () =
                    (Some "l", Some "r") ;
                    (None, None) ;
                    (None, None) ] in
-  match (Options.get_str_tuple_list hashtbl "tuple_str_list") with
+  match (Options.get_str_tuple_list hashtbl "tuple_str_list" ~sep:':' ()) with
   | `Ok s -> let _ = List.map2 (fun a b ->
       if not (is_eq_tup a b) then
         Alcotest.fail (Printf.sprintf "Tuple lists are not equal. Expected %s, got %s" (t_s a) (t_s b))
@@ -106,6 +127,8 @@ let test_options =
      "get_int on string", `Quick, test_get_int_str ;
      "get_str", `Quick, test_get_str ;
      "get_str_list", `Quick, test_get_str_list ;
+     "get_bool", `Quick, test_get_bool ;
+     "get_bool_list", `Quick, test_get_bool_list ;
      "get_dns_name", `Quick, test_get_dns_name ;
      "get_str_tuple_list", `Quick, test_get_str_tuple_list ;
    ]

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ depends: [  "lwt"
             "uuidm"
             "irmin-unix"
             "irmin" { >= "0.9.7" }
+            "git" { <= "1.6.2" }
             "xen-api-client"
             "xenctrl"
             "alcotest" ]

--- a/src/irmin_backend.mli
+++ b/src/irmin_backend.mli
@@ -25,7 +25,7 @@ val get_dns_db : t -> Dns.Loader.db Lwt.t
 val add_vm_dns : t -> vm_uuid:Uuidm.t -> dns_name:Dns.Name.t -> dns_ttl:int -> unit Lwt.t
 (** Add DNS record for VM *)
 
-val add_vm : t -> vm_uuid:Uuidm.t -> vm_ip:Ipaddr.V4.t -> vm_stop_mode:Vm_stop_mode.t -> response_delay:float -> vm_config:(string,string) Hashtbl.t -> unit Lwt.t
+val add_vm : t -> vm_uuid:Uuidm.t -> vm_ip:Ipaddr.V4.t -> vm_stop_mode:Vm_stop_mode.t -> response_delay:float -> wait_for_key:string option -> use_synjitsu:bool -> vm_config:(string,string) Hashtbl.t -> unit Lwt.t
 (** Add a new VM *)
 
 val get_vm_config : t -> vm_uuid:Uuidm.t -> (string, string) Hashtbl.t Lwt.t
@@ -78,6 +78,12 @@ val get_ip : t -> vm_uuid:Uuidm.t -> Ipaddr.V4.t option Lwt.t
 
 val set_ip : t -> vm_uuid:Uuidm.t -> Ipaddr.V4.t -> unit Lwt.t
 (** Set VM IP *)
+
+val get_wait_for_key : t -> vm_uuid:Uuidm.t -> string option Lwt.t
+(** Get key to wait for in Xenstore before returning DNS response *)
+
+val get_use_synjitsu : t -> vm_uuid:Uuidm.t -> bool Lwt.t
+(** Get synjitsu mode *)
 
 val get_vm_list : t -> Uuidm.t list Lwt.t
 (** Get list of registered VMs *)

--- a/src/jitsu.ml
+++ b/src/jitsu.ml
@@ -107,9 +107,8 @@ module Make (Vm_backend : Backends.VM_BACKEND) = struct
       Irmin_backend.inc_total_starts t.storage ~vm_uuid
     in
     let notify_synjitsu () =
-      t.log "jitsu jitsu" ;
       match t.synjitsu with
-      | None -> t.log "no jitsu" ;  Lwt.return_unit (* synjitsu not configured *)
+      | None -> Lwt.return_unit (* synjitsu not configured *)
       | Some s -> begin
           Irmin_backend.get_ip t.storage ~vm_uuid >>= fun r ->
           or_vm_backend_error "Unable to get MAC for VM" (Vm_backend.get_mac t.vm_backend) vm_uuid >>= fun vm_mac ->
@@ -258,8 +257,10 @@ module Make (Vm_backend : Backends.VM_BACKEND) = struct
 
   (** Process function for ocaml-dns. Starts new VMs from DNS queries or
       forwards request to a fallback resolver *)
-  let process t ~src:_ ~dst:_ packet =
-    t.log "process";
+  let process t ~src ~dst packet =
+    let (src,sport) = src in
+    let (dst,dport) = dst in
+    t.log (Printf.sprintf "dns: Query from %s:%d to %s:%d" (Ipaddr.to_string src) sport (Ipaddr.to_string dst) dport);
     Irmin_backend.get_dns_db t.storage >>= fun dns_db ->
     let open Packet in
     match packet.questions with

--- a/src/jitsu.mli
+++ b/src/jitsu.mli
@@ -61,4 +61,7 @@ module Make :
     val string_of_error: Backends.error -> string
     (** Convert backend error to string *)
 
+    val output_stats: t -> ?vm_uuids:(Uuidm.t list option) -> unit -> unit Lwt.t
+    (** Output stats for a list of UUIDs *)
+
   end

--- a/src/jitsu.mli
+++ b/src/jitsu.mli
@@ -35,7 +35,11 @@ module Make :
         where vm_count is the initial size of the hash table and use_synjitsu is the optional
         name or uuid of a synjitsu unikernel. *)
 
-    val process: t -> Dns.Packet.t Dns_server.process
+    val process: t -> 
+        src:Dns_server.ip_endpoint -> 
+        dst:Dns_server.ip_endpoint -> 
+        Dns.Packet.t -> 
+        Dns.Query.answer option Lwt.t
     (** Process function for ocaml-dns. Starts new VMs from DNS queries or
         forwards request to a fallback resolver *)
 

--- a/src/jitsu.mli
+++ b/src/jitsu.mli
@@ -35,11 +35,11 @@ module Make :
         where vm_count is the initial size of the hash table and use_synjitsu is the optional
         name or uuid of a synjitsu unikernel. *)
 
-    val process: t -> 
-        src:Dns_server.ip_endpoint -> 
-        dst:Dns_server.ip_endpoint -> 
-        Dns.Packet.t -> 
-        Dns.Query.answer option Lwt.t
+    val process: t ->
+      src:Dns_server.ip_endpoint ->
+      dst:Dns_server.ip_endpoint ->
+      Dns.Packet.t ->
+      Dns.Query.answer option Lwt.t
     (** Process function for ocaml-dns. Starts new VMs from DNS queries or
         forwards request to a fallback resolver *)
 
@@ -47,6 +47,8 @@ module Make :
       vm_ip:Ipaddr.V4.t -> vm_stop_mode:Vm_stop_mode.t ->
       dns_names:(Dns.Name.t list) -> dns_ttl:int ->
       response_delay:float ->
+      wait_for_key:string option ->
+      use_synjitsu:bool ->
       vm_config:(string, string) Hashtbl.t ->
       unit Lwt.t
     (** [add_vm t vm_name vm_stop_mode dns_name dns_ip dns_ttl response_delay vm_config] adds a VM to be

--- a/src/libxl_backend.ml
+++ b/src/libxl_backend.ml
@@ -337,7 +337,7 @@ let start_vm t uuid config =
               | None -> []
               | Some s -> s) in
             let disks = (
-              let lst = Options.(optional (get_str_tuple_list config "disk")) in
+              let lst = Options.(optional (get_str_tuple_list config "disk" ())) in
               match lst with
               | None -> []
               | Some s -> s) in

--- a/src/libxl_backend.ml
+++ b/src/libxl_backend.ml
@@ -18,8 +18,6 @@
 
 open Lwt.Infix
 
-module Client = Xs_client_lwt.Client(Xs_transport_lwt_unix_client)
-
 let debug = false
 
 exception Uuid_error of string
@@ -163,24 +161,10 @@ let get_dominfo_by_domid t vm_domid =
   in
   lookup_vm_by_predicate t domid_check
 
-let safe_xs_read_by_domid domid key =
-  let path = Printf.sprintf "/local/domain/%d/%s" domid key in
-  let safe_read h k =
-    Lwt.catch
-      (fun () -> Xs.read h k >>= fun v -> Lwt.return (Some v))
-      (function Xs_protocol.Enoent _ -> Lwt.return_none | e -> raise e)
-  in
-  Xs.make () >>= fun xsc ->
-  Xs.(immediate xsc (fun h ->
-      safe_read h path
-    )) >>= function
-  | None -> Lwt.return_none
-  | Some s -> Lwt.return (Some s)
-
 let safe_xs_read_by_vm t uuid key =
   match (get_dominfo_by_uuid t uuid) with
   | None -> Lwt.return_none
-  | Some dominfo -> safe_xs_read_by_domid (dominfo.Xenlight.Dominfo.domid) key
+  | Some dominfo -> Xenstore.read_by_domid (dominfo.Xenlight.Dominfo.domid) key
 
 let blocking_xenlight f =
   (* Xenlight wants to control SIGCHILD.
@@ -264,7 +248,7 @@ let lookup_vm_by_name t vm_name =
   let domids = List.map (fun di -> di.Xenlight.Dominfo.domid) (Xenlight.Dominfo.list !(t.context)) in
   let rec loop = function
     | domid :: rest -> begin
-        safe_xs_read_by_domid domid "name" >>= fun name ->
+        Xenstore.read_by_domid domid "name" >>= fun name ->
         match name with
         | None -> loop rest
         | Some name -> if name = vm_name then

--- a/src/main.ml
+++ b/src/main.ml
@@ -30,14 +30,16 @@ let info =
     List.map (fun x ->
         let (k,v) = x in
         `I ((Printf.sprintf "$(b,%s)" k), v)) l in
-  let man = [
-    `S "LIBVIRT CONFIGURATION"
-  ] @ (list_options Libvirt_backend.get_config_option_list) @ [
-      `S "XAPI CONFIGURATION" ;
-    ] @ (list_options Xapi_backend.get_config_option_list) @ [
-      `S "LIBXL CONFIGURATION" ;
-    ] @ (list_options Libxl_backend.get_config_option_list) @ [
-      `S "EXAMPLES";
+  let common_options =
+    [ ("response_delay", "Override default DNS query response delay for this unikernel. See also -d.") ;
+      ("wait_for_key", "Wait for this key to appear in Xenstore before responding to the DNS query. Sleeps for [response_delay] after the key appears. The key should be relative to /local/domain/[domid]/.") ;
+      ("use_synjitsu", "Enable Synjitsu for this domain if not 0 or absent (requires Synjitsu support enabled)") ] in
+  let man =
+    [ `S "COMMON CONFIGURATION" ] @ (list_options common_options) @
+    [ `S "LIBVIRT CONFIGURATION" ] @ (list_options Libvirt_backend.get_config_option_list) @
+    [ `S "XAPI CONFIGURATION" ] @ (list_options Xapi_backend.get_config_option_list) @
+    [ `S "LIBXL CONFIGURATION" ] @ (list_options Libxl_backend.get_config_option_list) @
+    [ `S "EXAMPLES";
       `P "$(b,jitsu -c xen:/// -f 8.8.8.8 dns=mirage.io,ip=10.0.0.1,vm=mirage-www)" ;
       `P "Connect to Xen via libvirt. Start unikernel $(b,mirage-www) on requests for $(b,mirage.io) and \
           return IP $(b,10.0.0.1) in DNS. Forward unknown requests to \
@@ -212,6 +214,22 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
              let dns_name = Options.get_dns_name vm_config "dns" in
              let vm_name = Options.get_str vm_config "name" in
              let vm_ip = Options.get_ipaddr vm_config "ip" in
+             let response_delay =  (* override default response_delay if key set in config *)
+               match (Options.get_float vm_config "response_delay") with
+               | `Error _ -> response_delay
+               | `Ok d -> d
+             in
+             let use_synjitsu =
+               match (Options.get_bool vm_config "use_synjitsu"), synjitsu with
+               | `Error _, _
+               | `Ok _, None -> false (* default to false if use_synjitsu is not set or synjitsu is not enabled *)
+               | `Ok v, Some _ -> v
+             in
+             let wait_for_key =
+               match Options.get_str vm_config "wait_for_key" with
+               | `Error _ -> None
+               | `Ok v -> Some v
+             in
              match dns_name, vm_name, vm_ip with
              | `Error e, _, _
              | _, `Error e, _
@@ -221,7 +239,7 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
                  | None -> raise (Failure (Printf.sprintf "Only IPv4 is supported. %s is not a valid IPv4 address." (Ipaddr.to_string vm_ip)))
                  | Some vm_ip -> begin
                      log (Printf.sprintf "Adding domain '%s' for VM '%s' with ip %s" (Dns.Name.to_string dns_name) vm_name (Ipaddr.V4.to_string vm_ip));
-                     or_abort (fun () -> Jitsu.add_vm t ~dns_names:[dns_name] ~vm_ip ~vm_stop_mode ~response_delay ~dns_ttl:ttl ~vm_config)
+                     or_abort (fun () -> Jitsu.add_vm t ~dns_names:[dns_name] ~vm_ip ~vm_stop_mode ~response_delay ~wait_for_key ~use_synjitsu ~dns_ttl:ttl ~vm_config)
                    end
                end
            ) in

--- a/src/main.ml
+++ b/src/main.ml
@@ -144,10 +144,12 @@ let or_abort f =
 let or_warn msg f =
   try f () with
   | Failure m -> (log (Printf.sprintf "Warning: %s\nReceived exception: %s" msg m)); ()
+  | e -> (log (Printf.sprintf "Warning: Unhandled exception: %s" (Printexc.to_string e))); ()
 
 let or_warn_lwt msg f =
   try f () with
   | Failure m -> (log (Printf.sprintf "Warning: %s\nReceived exception: %s" msg m)); Lwt.return_unit
+  | e -> (log (Printf.sprintf "Warning: Unhandled exception: %s" (Printexc.to_string e))); Lwt.return_unit
 
 let backend =
   let doc =
@@ -223,7 +225,7 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
                    end
                end
            ) in
-           Lwt_list.iter_p add_with_config map_domain
+           Lwt_list.iter_s add_with_config map_domain
            >>= fun () ->
            log (Printf.sprintf "Starting DNS server on %s:%d..." bindaddr bindport);
            try_lwt

--- a/src/main.ml
+++ b/src/main.ml
@@ -243,8 +243,8 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
                    end
                end
            ) in
-           Lwt_list.iter_s add_with_config map_domain
-           >>= fun () ->
+           Lwt_list.iter_s add_with_config map_domain >>= fun () ->
+           Jitsu.output_stats t () >>= fun () ->
            log (Printf.sprintf "Starting DNS server on %s:%d..." bindaddr bindport);
            try_lwt
              let processor = ((Dns_server.processor_of_process (Jitsu.process t))

--- a/src/main.ml
+++ b/src/main.ml
@@ -206,7 +206,7 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
      | `Error e -> raise (Failure (Printf.sprintf "Unable to connect to backend: %s" (Jitsu.string_of_error e)))
      | `Ok backend_t ->
        or_abort (fun () -> Jitsu.create backend_t log forward_resolver ~synjitsu ~persistdb ()) >>= fun t ->
-       Lwt.choose [(
+       Lwt.pick [(
            (* main thread, DNS server *)
            let add_with_config config_array = (
              let vm_config = (Hashtbl.create (Array.length config_array)) in

--- a/src/options.ml
+++ b/src/options.ml
@@ -110,14 +110,22 @@ let file_name_of_string_exn v key_name =
   | true, true -> raise (Invalid_value (Printf.sprintf "%s: '%s'. Kernel must be a file, not a directory." key_name v))
   | false, _ -> raise (Invalid_value (Printf.sprintf "%s: '%s'. File does not exist." key_name v))
 
+let bool_of_string_exn v key_name =
+  let f = [ "false" ; "0" ] in
+  let t = [ "true" ; "1" ] in
+  let v_lower = String.lowercase v in
+  if (List.mem v_lower t) then true else
+    if (List.mem v_lower f) then false else
+        raise (Invalid_format (Printf.sprintf "%s: '%s'. Invalid boolean value. Only true/false or 1/0 accepted." key_name v))
+
 let get_str config key =
   get config key (fun s _ -> s)
 
 let get_str_list config key =
   get_list config key (fun s _ -> s)
 
-let get_str_tuple_list config key =
-  get_tuple_list config key (fun s _ -> s) (fun s _ -> s)
+let get_str_tuple_list config key ?sep () =
+  get_tuple_list config key ?sep (fun s _ -> s) (fun s _ -> s)
 
 let get_ipaddr config key =
   get config key ipaddr_of_string_exn
@@ -148,3 +156,9 @@ let get_file_name config key =
 
 let get_file_name_list config key =
   get_list config key file_name_of_string_exn
+
+let get_bool config key =
+  get config key bool_of_string_exn
+
+let get_bool_list config key =
+  get_list config key bool_of_string_exn

--- a/src/options.ml
+++ b/src/options.ml
@@ -115,8 +115,8 @@ let bool_of_string_exn v key_name =
   let t = [ "true" ; "1" ] in
   let v_lower = String.lowercase v in
   if (List.mem v_lower t) then true else
-    if (List.mem v_lower f) then false else
-        raise (Invalid_format (Printf.sprintf "%s: '%s'. Invalid boolean value. Only true/false or 1/0 accepted." key_name v))
+  if (List.mem v_lower f) then false else
+    raise (Invalid_format (Printf.sprintf "%s: '%s'. Invalid boolean value. Only true/false or 1/0 accepted." key_name v))
 
 let get_str config key =
   get config key (fun s _ -> s)

--- a/src/xenstore.ml
+++ b/src/xenstore.ml
@@ -56,7 +56,7 @@ let wait path ?value:(value=None) ?timeout:(timeout=5.0) () =
     Lwt_unix.sleep timeout >>= fun () ->
     Lwt.return `Timeout
   in
-  Lwt.choose [
+  Lwt.pick [
     wait_for_key () ;
     wait_for_timeout () ;
   ]

--- a/src/xenstore.ml
+++ b/src/xenstore.ml
@@ -1,0 +1,66 @@
+(*
+ * Copyright (c) 2015 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2015 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Lwt.Infix
+
+let read path =
+  let safe_read h k =
+    Lwt.catch
+      (fun () -> Xs.read h k >>= fun v -> Lwt.return (Some v))
+      (function Xs_protocol.Enoent _ -> Lwt.return_none | e -> raise e)
+  in
+  Xs.make () >>= fun xsc ->
+  Xs.(immediate xsc (fun h ->
+      safe_read h path
+    )) >>= function
+  | None -> Lwt.return_none
+  | Some s -> Lwt.return (Some s)
+
+
+let read_by_domid domid key =
+  let path = Printf.sprintf "/local/domain/%d/%s" domid key in
+  read path
+
+(* wait for key/value to appear in xenstore*)
+let wait path ?value:(value=None) ?timeout:(timeout=5.0) () =
+  let wait_for_key () =
+    let safe_read h k =
+      Lwt.catch
+        (fun () -> Xs.read h k >>= fun v -> Lwt.return (Some v))
+        (function Xs_protocol.Enoent _ -> Lwt.return_none | e -> raise e)
+    in
+    Xs.make () >>= fun xsc ->
+    Xs.(wait xsc (fun h ->
+        safe_read h path >>= fun r ->
+        match r, value with
+        | None,_   -> raise Xs_protocol.Eagain
+        | Some x, Some v -> if x = v then Lwt.return `Ok else raise Xs_protocol.Eagain
+        | Some _, None -> Lwt.return `Ok
+      ))
+  in
+  let wait_for_timeout () =
+    Lwt_unix.sleep timeout >>= fun () ->
+    Lwt.return `Timeout
+  in
+  Lwt.choose [
+    wait_for_key () ;
+    wait_for_timeout () ;
+  ]
+
+let wait_by_domid domid key =
+  wait (Printf.sprintf "/local/domain/%d/%s" domid key)
+


### PR DESCRIPTION
 - Support waiting for a key to appear in Xenstore before sending DNS reply
 - Allow use_synjitsu, delay and wait_for_key to be set per domain
 - Enable Travis
 - Improve logging + misc cleanup
