### PR TITLE
Remove camlp4 references

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -15,7 +15,7 @@ PKG xenlight
 PKG uuidm
 PKG xen-api-client
 PKG alcotest
-EXT lwt
+PKG lwt.ppx
 S src/**
 S lib_test/**
 B bin

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifeq ($(HAS_XL), 1)
 endif
 
 BASE_FILES=vm_stop_mode.ml vm_state.ml xenstore.ml backends.mli vm_backends.ml options.ml rumprun.ml $(BACKEND_FILES) dns_helpers.ml irmin_backend.ml synjitsu.mli synjitsu.ml jitsu.mli jitsu.ml
-BASE_PKG=-package lwt.syntax,lwt,dns.lwt,cmdliner,ezxmlm,ipaddr,str,conduit,conduit.lwt-unix,irmin.unix,xenstore,xenstore_transport,xenstore_transport.lwt,uuidm$(BACKEND_PKG)
+BASE_PKG=-package lwt.ppx,lwt,dns.lwt,cmdliner,ezxmlm,ipaddr,str,conduit,conduit.lwt-unix,irmin.unix,xenstore,xenstore_transport,xenstore_transport.lwt,uuidm$(BACKEND_PKG)
 BASE_FILES_PREFIX=$(addprefix $(SRC)/,$(BASE_FILES))
 
 TEST_SRC=$(PWD)/lib_test
@@ -59,10 +59,10 @@ $(BIN)/jitsu: $(BASE_FILES_PREFIX) $(MAIN_FILE_PREFIX) $(VERSION_ML)
 		echo "Warning: No VM backends found. Install xenctrl, xen-api-client or libvirt with opam to add a backend." || \
 		echo 'Detected backends: $(subst :, ,$(BACKENDS))'
 	mkdir -p $(BIN)
-	cd $(SRC) ; ocamlfind $(OCAMLOPT) $(INCLUDE) $(BASE_PKG) $(OPT) $(VERSION_ML) $(BASE_FILES) $(MAIN_FILE) -o $(BIN)/jitsu -syntax camlp4o
+	cd $(SRC) ; ocamlfind $(OCAMLOPT) $(INCLUDE) $(BASE_PKG) $(OPT) $(VERSION_ML) $(BASE_FILES) $(MAIN_FILE) -o $(BIN)/jitsu
 
 $(BIN)/test: $(BIN)/jitsu $(TEST_FILES_PREFIX) $(TEST_MAIN_FILE_PREFIX)
-	cd $(TEST_SRC) ; ocamlfind $(OCAMLOPT) $(TEST_INCLUDE) $(TEST_PKG) $(OPT) $(BASE_FILES_PREFIX) $(TEST_FILES) $(TEST_MAIN_FILE) -o $(BIN)/test -syntax camlp4o
+	cd $(TEST_SRC) ; ocamlfind $(OCAMLOPT) $(TEST_INCLUDE) $(TEST_PKG) $(OPT) $(BASE_FILES_PREFIX) $(TEST_FILES) $(TEST_MAIN_FILE) -o $(BIN)/test
 
 test: $(BIN)/test
 	@echo "Running tests..."

--- a/src/jitsu.ml
+++ b/src/jitsu.ml
@@ -116,7 +116,7 @@ module Make (Vm_backend : Backends.VM_BACKEND) (Storage_backend : Backends.STORA
           match r, vm_mac with
           | Some ip, [m] -> begin
               t.log (Printf.sprintf "Notifying Synjitsu of MAC %s" (Macaddr.to_string m));
-              try_lwt
+              try%lwt
                 Synjitsu.send_garp s m ip
               with e ->
                 t.log (Printf.sprintf "Got exception %s" (Printexc.to_string e));

--- a/src/main.ml
+++ b/src/main.ml
@@ -164,7 +164,7 @@ let or_warn msg f =
   | e -> (log (Printf.sprintf "Warning: Unhandled exception: %s" (Printexc.to_string e))); ()
 
 let or_warn_lwt msg f =
-  try_lwt f () with
+  try%lwt f () with
   | Failure m -> (log (Printf.sprintf "Warning: %s\nReceived exception: %s" msg m)); Lwt.return_unit
   | e -> (log (Printf.sprintf "Warning: Unhandled exception: %s" (Printexc.to_string e))); Lwt.return_unit
 
@@ -286,7 +286,7 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
            Lwt_list.iter_s add_with_config map_domain >>= fun () ->
            Jitsu.output_stats t () >>= fun () ->
            log (Printf.sprintf "Starting DNS server on %s:%d..." bindaddr bindport);
-           try_lwt
+           try%lwt
              let processor = ((Dns_server.processor_of_process (Jitsu.process t))
                               :> (module Dns_server.PROCESSOR)) in
              Dns_server_unix.serve_with_processor ~address:bindaddr ~port:bindport ~processor
@@ -297,7 +297,7 @@ let jitsu backend connstr bindaddr bindport forwarder forwardport response_delay
              Lwt.return_unit);
 
           (* maintenance thread, delay in seconds *)
-          (try_lwt
+          (try%lwt
              maintenance_thread t 5.0
            with
            | e -> log (Printf.sprintf "Maintenance thread exited unexpectedly with exception: %s" (Printexc.to_string e)); Lwt.return_unit

--- a/src/synjitsu.ml
+++ b/src/synjitsu.ml
@@ -62,11 +62,11 @@ module Make (Backend : Backends.VM_BACKEND) = struct
 
   let connect t =
     (* TODO clean up exception mess *)
-    try_lwt
+    try%lwt
       if !(t.is_connecting) = false then
         begin
           t.is_connecting := true;
-          (try_lwt (disconnect t) with _ -> Lwt.return_unit) >>= fun () -> (* disconnect just in case, ignore result *)
+          (try%lwt (disconnect t) with _ -> Lwt.return_unit) >>= fun () -> (* disconnect just in case, ignore result *)
           Lwt_unix.sleep 1.0 >>= fun () -> (* wait, just in case *)
           t.log "synjitsu: Connecting...\n";
           or_error "synjitsu: Unable to find synjitsu VM dom id for vchan connection" (Backend.get_domain_id t.backend) t.vm_uuid >>= fun domid ->
@@ -88,7 +88,7 @@ module Make (Backend : Backends.VM_BACKEND) = struct
   let send t buf =
     match !(t.oc) with
     | None -> t.log "synjitsu: Unable to send - message dropped. Trying to connect...\n"; ignore_result (connect t); Lwt.return_unit
-    | Some oc -> try_lwt
+    | Some oc -> try%lwt
         Lwt_io.write_from_string_exactly oc (Cstruct.to_string buf) 0 (Cstruct.len buf)
       with
         End_of_file -> t.log "synjitsu: disconnected.\n" ; ignore_result (connect t); Lwt.return_unit


### PR DESCRIPTION
Just a mechanical replacement of `try_lwt` and `lwt _ = _ in` to `try%lwt` and `let%lwt _ = _ in`, and updates to the `Makefile` and `.merlin` file, but the tests still pass (not 100% sure what the tests cover though).
