### PR TITLE
Fix various warnings

### DIFF
--- a/src/libxl_backend.ml
+++ b/src/libxl_backend.ml
@@ -39,9 +39,9 @@ module Make = struct
 
   let bytes_of_int_array a =
     (* TODO: Probably a better way to do this... *)
-    let s = String.create (Array.length a) in
+    let s = Bytes.create (Array.length a) in
     Array.iteri (fun i v ->
-        String.set s i (Char.chr v)) a;
+        Bytes.set s i (Char.chr v)) a;
     s
 
   let int_array_of_string a =

--- a/src/main.ml
+++ b/src/main.ml
@@ -147,7 +147,7 @@ let synjitsu_domain_uuid =
 let persistdb =
   let doc =
     "Store the Irmin database in the specified path. The default is to store the database in memory only. \
-     Note that modifying this database while Jitsu is running is currently unsupported and may crash Jitsu
+     Note that modifying this database while Jitsu is running is currently unsupported and may crash Jitsu \
      or have other unexpected results." in
   Arg.(value & opt (some string) None & info [ "persistdb" ] ~docv:"path" ~doc)
 


### PR DESCRIPTION
Fixes warnings re: deprecated `String` vs `Bytes`, and an unescaped new-line in a string.
